### PR TITLE
Added a simple middleware to improve parsing out query and hash parameters

### DIFF
--- a/router.js
+++ b/router.js
@@ -16,7 +16,6 @@ var UrlRouter = function(argo) {
         env.router = {};
         var reqUrl = env.request.url;
         var parsedReqUrl = url.parse(reqUrl, true);
-        env.request.url = parsedReqUrl.pathname;
         if(parsedReqUrl.query) {
           env.router.query = parsedReqUrl.query;
         } else if(parsedReqUrl.hash) {
@@ -53,6 +52,9 @@ UrlRouter.prototype.find = function(path, method) {
   var found = false;
   var params = {};
   method = method.toLowerCase();
+
+  var parsedPath = url.parse(path, true);
+  path = parsedPath.pathname;
 
   var self = this;
   this._routerKeys.forEach(function(key) {


### PR DESCRIPTION
``` javascript
  if(argo) {
    argo
    .use(function(handle){
      handle("request", {affinity:"hoist"}, function(env, next){
        env.router = {};
        var reqUrl = env.request.url;
        var parsedReqUrl = url.parse(reqUrl, true);
        env.request.url = parsedReqUrl.pathname;
        if(parsedReqUrl.query) {
          env.router.query = parsedReqUrl.query;
        } else if(parsedReqUrl.hash) {
          env.router.hash = parsedReqUrl.hash;
        }
        next(env);
      });
    });
  }
```

Here is the simple middleware addition added to the argo-url-router. It essentially just uses the stock node url parser to pick out all the stuff we need. We don't even have to slice up the url afterwards because it gives us a cleaned up path in the `pathname` property of the parsed url obj. Good stuff.
